### PR TITLE
Potential fix for code scanning alert no. 46: Double escaping or unescaping

### DIFF
--- a/src/bot/services/youtube-websub.js
+++ b/src/bot/services/youtube-websub.js
@@ -404,7 +404,6 @@ async function parseAtomFeed(xml, channelId) {
       if (videoId && /^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
         // Sanitize title to prevent XSS - decode HTML entities in correct order
         let sanitizedTitle = (title || 'Unknown Title')
-          .replace(/&amp;/g, '&')     // Must be first to prevent double-decoding
           .replace(/&lt;/g, '<')
           .replace(/&gt;/g, '>')
           .replace(/&quot;/g, '"')


### PR DESCRIPTION
Potential fix for [https://github.com/husniaditya/dc-ai_bot/security/code-scanning/46](https://github.com/husniaditya/dc-ai_bot/security/code-scanning/46)

To fix this issue, the order of replacements must be changed so that ampersands (`&amp;`) are decoded *last*, after all other HTML entities have been decoded. This follows the guidance that the escape character should be unescaped last. In detail:
- Change the chained `.replace` calls inside calculation of `sanitizedTitle` so that `&quot;`, `&lt;`, `&gt;`, and `&#39;` are decoded **before** decoding `&amp;`.
- Remove the redundant second `.replace(/&amp;/g, '&')` call.
These changes should be made inside the handling of `sanitizedTitle` (lines 406–413) in the block shown.

No new methods are required, but if the code is ever made more robust, a proper library should be considered. For now, this change only requires a simple reordering of replace calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
